### PR TITLE
Initial commits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN lein deps
 COPY . /usr/src/voter-registration-http-api
 
 RUN lein test
-RUN lein immutant war --name voter-registration-http-api --destination target --nrepl-port=11111 --nrepl-start --nrepl-host=0.0.0.0
+RUN lein immutant war --name voter-registration-http-api --destination target --nrepl-port=11789 --nrepl-start --nrepl-host=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,19 @@ app:
     - wildfly
   environment:
     ALLOWED_ORIGINS: :all
+voterregistrationworks:
+  build: ../voter-registration-works
+  links:
+    - rabbitmq
+    - wildfly
+    - datomic
+  environment:
+    VOTER_REGISTRATION_WORKS_DATOMIC_URI: datomic:dev://datomic:4334/voter-registration-works
 wildfly:
   image: quay.io/democracyworks/wildfly:8.2.0.Final
   links:
     - rabbitmq
+    - datomic
   ports:
     - "59990:9990"
     - "58080:8080"
@@ -21,3 +30,10 @@ rabbitmq:
     - "45672:5672"
     - "55672:15672"
   hostname: rabbitmq
+datomic:
+  image: quay.io/democracyworks/datomic-tx:0.9.5153
+  hostname: datomic
+  ports:
+    - "4334:4334"
+    - "4335:4335"
+    - "4336:4336"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [turbovote.resource-config "0.2.0"]
                  [com.novemberain/langohr "3.3.0"]
-                 [prismatic/schema "0.4.3"]
+                 [prismatic/schema "0.4.4"]
                  [ch.qos.logback/logback-classic "1.1.3"]
 
                  ;; core.async has to come before pedestal or kehaar.wire-up will
@@ -18,7 +18,7 @@
                  
                  [io.pedestal/pedestal.service "0.4.0"]
                  [io.pedestal/pedestal.service-tools "0.4.0"]
-                 [democracyworks/pedestal-toolbox "0.6.1"]
+                 [democracyworks/pedestal-toolbox "0.6.2"]
 
                  ;; this has to go before pedestal.immutant
                  ;; until this is fixed:

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -3,4 +3,6 @@
           :allowed-origins #resource-config/edn #resource-config/env "ALLOWED_ORIGINS"}
  :rabbitmq {:connection {:host #resource-config/env "RABBITMQ_PORT_5672_TCP_ADDR"
                          :port #resource-config/edn #resource-config/env "RABBITMQ_PORT_5672_TCP_PORT"}
-            :queues {"voter-registration-http-api.ok" {:exclusive false :durable true :auto-delete false}}}}
+            :queues {"voter-registration-http-api.ok" {:exclusive false :durable true :auto-delete false}
+                     "voter-registration-works.registration-methods.read" {:exclusive false :durable true :auto-delete false}
+                     "voter-registration-works.voter.register" {:exclusive false :durable true :auto-delete false}}}}

--- a/src/voter_registration_http_api/channels.clj
+++ b/src/voter_registration_http_api/channels.clj
@@ -5,6 +5,11 @@
 (defonce ok-requests (async/chan))
 (defonce ok-responses (async/chan))
 
+(defonce registration-methods-read (async/chan))
+
+(defonce voter-register (async/chan))
+
 (defn close-all! []
-  (doseq [c [ok-requests ok-responses]]
+  (doseq [c [ok-requests ok-responses registration-methods-read
+             voter-register]]
     (async/close! c)))

--- a/src/voter_registration_http_api/queue.clj
+++ b/src/voter_registration_http_api/queue.clj
@@ -19,7 +19,20 @@
                               (config [:rabbitmq :queues "voter-registration-http-api.ok"])
                               channels/ok-requests
                               channels/ok-responses)]
-          external-services []
+          external-services [(wire-up/external-service
+                              connection
+                              ""
+                              "voter-registration-works.registration-methods.read"
+                              (config [:rabbitmq :queues "voter-registration-works.registration-methods.read"])
+                              1000
+                              channels/registration-methods-read)
+                             (wire-up/external-service
+                              connection
+                              ""
+                              "voter-registration-works.voter.register"
+                              (config [:rabbitmq :queues "voter-registration-works.voter.register"])
+                              1000
+                              channels/voter-register)]
           outgoing-events []]
 
       (wire-up/start-responder! channels/ok-requests

--- a/src/voter_registration_http_api/queue.clj
+++ b/src/voter_registration_http_api/queue.clj
@@ -6,7 +6,8 @@
             [kehaar.rabbitmq]
             [voter-registration-http-api.channels :as channels]
             [voter-registration-http-api.handlers :as handlers]
-            [turbovote.resource-config :refer [config]]))
+            [turbovote.resource-config :refer [config]]
+            [voter-registration-http-api.service :refer [response-timeout]]))
 
 (defn initialize []
   (let [max-retries 5
@@ -24,14 +25,14 @@
                               ""
                               "voter-registration-works.registration-methods.read"
                               (config [:rabbitmq :queues "voter-registration-works.registration-methods.read"])
-                              1000
+                              response-timeout
                               channels/registration-methods-read)
                              (wire-up/external-service
                               connection
                               ""
                               "voter-registration-works.voter.register"
                               (config [:rabbitmq :queues "voter-registration-works.voter.register"])
-                              1000
+                              response-timeout
                               channels/voter-register)]
           outgoing-events []]
 

--- a/src/voter_registration_http_api/service.clj
+++ b/src/voter_registration_http_api/service.clj
@@ -29,6 +29,9 @@
     500))
 
 (defn rabbit-result->http-status
+  "Converts result messages from RabbitMQ into HTTP status codes.
+  This currently only works with error responses, which isn't ideal, but making
+  it work with :ok responses will require more work outside of this fn. TODO"
   [rabbit-result]
   (case (:status rabbit-result)
     :error (rabbit-error->http-status (:error rabbit-result))

--- a/src/voter_registration_http_api/service.clj
+++ b/src/voter_registration_http_api/service.clj
@@ -63,13 +63,14 @@
         (go
           (let [result (alt! (timeout response-timeout) {:status :error
                                                          :error {:type :timeout}}
-                             result-chan ([v] v))]
+                             result-chan ([v] v))
+                result-without-status (dissoc result :status)]
             (if (= :ok (:status result))
               (assoc ctx :response
-                     (ring-resp/response (dissoc result :status)))
+                     (ring-resp/response result-without-status))
               (let [http-status (rabbit-result->http-status result)]
                 (assoc ctx :response
-                       (-> result
+                       (-> result-without-status
                            ring-resp/response
                            (ring-resp/status http-status)))))))))}))
 

--- a/src/voter_registration_http_api/service.clj
+++ b/src/voter_registration_http_api/service.clj
@@ -8,13 +8,70 @@
             [pedestal-toolbox.params :refer :all]
             [pedestal-toolbox.content-negotiation :refer :all]
             [kehaar.core :as k]
-            [clojure.core.async :refer [chan go alt! timeout]]))
+            [clojure.core.async :refer [chan go alt! timeout]]
+            [voter-registration-http-api.voter-registration-works :as vrw]))
 
 (def ping
   (interceptor
    {:enter
     (fn [ctx]
       (assoc ctx :response (ring-resp/response "OK")))}))
+
+(defn rabbit-error->http-status
+  [rabbit-error]
+  (case (:type rabbit-error)
+    :semantic 400
+    :validation 400
+    :server 500
+    :timeout 504
+    500))
+
+(defn rabbit-result->http-status
+  [rabbit-result]
+  (case (:status rabbit-result)
+    :error (rabbit-error->http-status (:error rabbit-result))
+    500))
+
+(def response-timeout 5000)
+
+(def registration-methods-read
+  (interceptor
+   {:enter
+    (fn [ctx]
+      (let [state (get-in ctx [:request :path-params :state])
+            result-chan (vrw/registration-methods-read {:state state})]
+        (go
+          (let [result (alt! (timeout response-timeout) {:status :error
+                                                         :error {:type :timeout}}
+                             result-chan ([v] v))]
+            (if (= :ok (:status result))
+              (let [methods (:registration-methods result)]
+                (assoc ctx :response
+                       (ring-resp/response methods)))
+              (let [http-status (rabbit-result->http-status result)]
+                (assoc ctx :response
+                       (-> result
+                           ring-resp/response
+                           (ring-resp/status http-status)))))))))}))
+
+(def voter-register
+  (interceptor
+   {:enter
+    (fn [ctx]
+      (let [voter (get-in ctx [:request :body-params])
+            result-chan (vrw/voter-register voter)]
+        (go
+          (let [result (alt! (timeout response-timeout) {:status :error
+                                                         :error {:type :timeout}}
+                             result-chan ([v] v))]
+            (if (= :ok (:status result))
+              (assoc ctx :response
+                     (ring-resp/response (dissoc result :status)))
+              (let [http-status (rabbit-result->http-status result)]
+                (assoc ctx :response
+                       (-> result
+                           ring-resp/response
+                           (ring-resp/status http-status)))))))))}))
 
 (defroutes routes
   [[["/"
@@ -24,7 +81,9 @@
                                                        "application/transit+msgpack"
                                                        "application/json"
                                                        "text/plain"])]
-     ["/ping" {:get [:ping ping]}]]]])
+     ["/ping" {:get [:ping ping]}]
+     ["/registration-methods/:state" {:get [:get-registration-methods registration-methods-read]}]
+     ["/registrations" {:post [:post-registration voter-register]}]]]])
 
 (defn service []
   {::env :prod

--- a/src/voter_registration_http_api/service.clj
+++ b/src/voter_registration_http_api/service.clj
@@ -11,6 +11,8 @@
             [clojure.core.async :refer [chan go alt! timeout]]
             [voter-registration-http-api.voter-registration-works :as vrw]))
 
+(def response-timeout 5000)
+
 (def ping
   (interceptor
    {:enter
@@ -31,8 +33,6 @@
   (case (:status rabbit-result)
     :error (rabbit-error->http-status (:error rabbit-result))
     500))
-
-(def response-timeout 5000)
 
 (def registration-methods-read
   (interceptor

--- a/src/voter_registration_http_api/voter_registration_works.clj
+++ b/src/voter_registration_http_api/voter_registration_works.clj
@@ -1,0 +1,6 @@
+(ns voter-registration-http-api.voter-registration-works
+  (:require [kehaar.wire-up :as wire-up]
+            [voter-registration-http-api.channels :as channels]))
+
+(def registration-methods-read (wire-up/async->fn channels/registration-methods-read))
+(def voter-register (wire-up/async->fn channels/voter-register))

--- a/test/voter_registration_http_api/service_test.clj
+++ b/test/voter_registration_http_api/service_test.clj
@@ -4,9 +4,13 @@
             [clojure.edn :as edn]
             [cognitect.transit :as transit]
             [clojure.core.async :as async]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all]
+            [clojure.string :as str]
+            [voter-registration-http-api.channels :as channels]
+            [voter-registration-http-api.service :as service])
+  (:import [java.io ByteArrayInputStream ByteArrayOutputStream]))
 
-(def test-server-port 56000) ; FIXME: Pick a port unique to this project
+(def test-server-port 56789)
 
 (defn start-test-server [run-tests]
   (server/start-http-server {:io.pedestal.http/port test-server-port})
@@ -22,3 +26,215 @@
                              {:headers {:accept "text/plain"}})]
       (is (= 200 (:status response)))
       (is (= "OK" (:body response))))))
+
+(deftest registration-methods-read-test
+  (testing "GET to /registration-methods/:state puts appropriate read message
+            on registration-methods-read channel"
+    (let [http-response-ch (async/thread
+                             (http/get (str/join "/" [root-url
+                                                      "registration-methods"
+                                                      "co"])
+                                       {:headers {:accept "application/edn"}}))
+          [response-ch message] (async/alt!! channels/registration-methods-read ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])
+          response {:status :ok
+                    :registration-methods {:paper {:acceptable-forms [:nvrf]}
+                                           :online {:supports-iframe false
+                                                    :url "https://fake.ovr.site"}}}]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch response)
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)
+            body-data (-> http-response :body edn/read-string)]
+        (assert (not= http-response ::timeout))
+        (is (= "co" (:state message)))
+        (is (= 200 (:status http-response)))
+        (is (= (:registration-methods response) body-data)))))
+  (testing "GET to /registration-methods/:state can respond with Transit"
+    (let [http-response-ch (async/thread
+                             (http/get (str/join "/" [root-url
+                                                      "registration-methods"
+                                                      "ny"])
+                                       {:headers {:accept "application/transit+json"}}))
+          [response-ch message] (async/alt!! channels/registration-methods-read ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])
+          response {:status :ok
+                    :registration-methods {:paper {:acceptable-forms [:nvrf]}
+                                           :online {:supports-iframe false
+                                                    :url "https://fake.nyovr.site"}}}]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch response)
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)
+            transit-in (ByteArrayInputStream. (-> http-response
+                                                  :body
+                                                  (.getBytes "UTF-8")))
+            transit-reader (transit/reader transit-in :json)
+            body-data (transit/read transit-reader)]
+        (assert (not= http-response ::timeout))
+        (is (= "ny" (:state message)))
+        (is (= 200 (:status http-response)))
+        (is (= (:registration-methods response) body-data)))))
+  (testing "error from backend service results in HTTP server error response"
+    (let [http-response-ch (async/thread
+                             (http/get (str/join "/" [root-url
+                                                      "registration-methods"
+                                                      "ny"])
+                                       {:headers {:accept "application/edn"}
+                                        :throw-exceptions false}))
+          [response-ch message] (async/alt!! channels/registration-methods-read ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :error
+                              :error {:type :server}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= 500 (:status http-response))))))
+  (testing "no response from backend service results in HTTP gateway timeout error response"
+    (with-redefs [service/response-timeout 500]
+      (let [http-response-ch (async/thread
+                               (http/get (str/join "/" [root-url
+                                                        "registration-methods"
+                                                        "ok"])
+                                         {:headers {:accept "application/edn"}
+                                          :throw-exceptions false}))
+            [response-ch message] (async/alt!! channels/registration-methods-read ([v] v)
+                                               (async/timeout 1000) [nil ::timeout])]
+        (assert (not= message ::timeout))
+        (let [http-response (async/alt!! http-response-ch ([v] v)
+                                         (async/timeout 1000) ::timeout)]
+          (assert (not= http-response ::timeout))
+          (is (= 504 (:status http-response))))))))
+
+(deftest voter-register-test
+  (testing "POST to /registrations puts appropriate voter.register message
+            on voter-register channel"
+    (let [post-data {:state :ok
+                     :method :paper
+                     :voter {:email "rockiesgm@example.com"
+                             :first-name "Walt"
+                             :last-name "Weiss"
+                             :citizenship "US"
+                             :date-of-birth #inst "1963-11-28"
+                             :register-address :physical
+                             :addresses {:physical {:street "8145 NE 139th St"
+                                                    :city "Edmond"
+                                                    :state "OK"
+                                                    :postal-code "73013"}}}}
+          http-response-ch (async/thread
+                             (http/post (str/join "/" [root-url
+                                                       "/registrations"])
+                                        {:headers {:accept "application/edn"
+                                                   :content-type "application/edn"}
+                                         :body (pr-str post-data)}))
+          [response-ch message] (async/alt!! channels/voter-register ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])
+          response {:status :ok
+                    :next {:paper {:acceptable-forms [:nvrf]}}}]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch response)
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)
+            body-data (-> http-response :body edn/read-string)]
+        (assert (not= http-response ::timeout))
+        (is (= :ok (:state message)))
+        (is (= 200 (:status http-response)))
+        (is (= (dissoc response :status) body-data)))))
+  (testing "GET to /registration-methods/:state can receive & respond with Transit"
+    (let [post-data {:state :ny
+                     :method :paper
+                     :voter {:email "rockiesgm@example.com"
+                             :first-name "Walt"
+                             :last-name "Weiss"
+                             :citizenship "US"
+                             :date-of-birth #inst "1963-11-28"
+                             :register-address :physical
+                             :addresses {:physical {:street "8145 NE 139th St"
+                                                    :city "Edmond"
+                                                    :state "OK"
+                                                    :postal-code "73013"}}}}
+          transit-out (ByteArrayOutputStream.)
+          transit-writer (transit/writer transit-out :json)
+          post-body (do (transit/write transit-writer post-data)
+                        (.toString transit-out "UTF-8"))
+          http-response-ch (async/thread
+                             (http/post (str/join "/" [root-url
+                                                      "registrations"])
+                                        {:headers {:accept "application/transit+json"
+                                                   :content-type "application/transit+json"}
+                                         :body post-body}))
+          [response-ch message] (async/alt!! channels/voter-register ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])
+          response {:status :ok
+                    :next {:paper {:acceptable-forms [:nvrf]}}}]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch response)
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)
+            transit-in (ByteArrayInputStream. (-> http-response
+                                                  :body
+                                                  (.getBytes "UTF-8")))
+            transit-reader (transit/reader transit-in :json)
+            body-data (transit/read transit-reader)]
+        (assert (not= http-response ::timeout))
+        (is (= :ny (:state message)))
+        (is (= 200 (:status http-response)))
+        (is (= (dissoc response :status) body-data)))))
+  (testing "error from backend service results in HTTP server error response"
+    (let [post-data {:state :co
+                     :method :online
+                     :voter {:email "rockiesgm@example.com"
+                             :first-name "Walt"
+                             :last-name "Weiss"
+                             :citizenship "US"
+                             :date-of-birth #inst "1963-11-28"
+                             :register-address :physical
+                             :addresses {:physical {:street "8145 NE 139th St"
+                                                    :city "Edmond"
+                                                    :state "OK"
+                                                    :postal-code "73013"}}}}
+          http-response-ch (async/thread
+                             (http/post (str/join "/" [root-url
+                                                       "registrations"])
+                                        {:headers {:accept "application/edn"
+                                                   :content-type "application/edn"}
+                                         :body (pr-str post-data)
+                                         :throw-exceptions false}))
+          [response-ch message] (async/alt!! channels/voter-register ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :error
+                              :error {:type :server}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= 500 (:status http-response))))))
+  (testing "no response from backend service results in HTTP gateway timeout error response"
+    (with-redefs [service/response-timeout 500]
+      (let [post-data {:state :co
+                       :method :online
+                       :voter {:email "rockiesgm@example.com"
+                               :first-name "Walt"
+                               :last-name "Weiss"
+                               :citizenship "US"
+                               :date-of-birth #inst "1963-11-28"
+                               :register-address :physical
+                               :addresses {:physical {:street "8145 NE 139th St"
+                                                      :city "Edmond"
+                                                      :state "OK"
+                                                      :postal-code "73013"}}}}
+            http-response-ch (async/thread
+                               (http/post (str/join "/" [root-url
+                                                         "registrations"])
+                                          {:headers {:accept "application/edn"
+                                                     :content-type "application/edn"}
+                                           :body (pr-str post-data)
+                                           :throw-exceptions false}))
+            [response-ch message] (async/alt!! channels/voter-register ([v] v)
+                                               (async/timeout 1000) [nil ::timeout])]
+        (assert (not= message ::timeout))
+        (let [http-response (async/alt!! http-response-ch ([v] v)
+                                         (async/timeout 1000) ::timeout)]
+          (assert (not= http-response ::timeout))
+          (is (= 504 (:status http-response))))))))


### PR DESCRIPTION
[Pivotal card](https://www.pivotaltracker.com/story/show/99240330)

This implements the `/registration-options/:state` and `/registrations` HTTP API gateway endpoints called for in the card.

It has some basic tests and its docker-compose.yml spins up voter-registration-works and its dependencies so you can verify that everything lines up end-to-end. I've done that locally too.