### PR TITLE
Pass language param

### DIFF
--- a/src/voter_registration_http_api/service.clj
+++ b/src/voter_registration_http_api/service.clj
@@ -18,6 +18,12 @@
     (fn [ctx]
       (assoc ctx :response (ring-resp/response "OK")))}))
 
+(defn language-coercer
+  [params]
+  (if-let [language (:language params)]
+    {:language (keyword language)}
+    {}))
+
 (defroutes routes
   [[["/"
      ^:interceptors [(body-params)
@@ -34,11 +40,10 @@
       ^:interceptors [(bifrost.i/update-in-response [:body :registration-methods]
                                                     [:body] identity)
                       (bifrost.i/update-in-request [:query-params]
-                                                   (fn [params]
-                                                     (if-let [language (:language params)]
-                                                       {:language (keyword language)}
-                                                       {})))]]
+                                                   language-coercer)]]
      ["/registrations"
+      ^:interceptors [(bifrost.i/update-in-request [:query-params]
+                                                   language-coercer)]
       {:post [:post-registration (bifrost/interceptor
                                   channels/voter-register
                                   (config [:timeouts :voter-register]))]}]

--- a/src/voter_registration_http_api/service.clj
+++ b/src/voter_registration_http_api/service.clj
@@ -31,19 +31,17 @@
                                                        "application/transit+json"
                                                        "application/transit+msgpack"
                                                        "application/json"
-                                                       "text/plain"])]
+                                                       "text/plain"])
+                     (bifrost.i/update-in-request [:query-params]
+                                                   language-coercer)]
      ["/ping" {:get [:ping ping]}]
      ["/registration-methods/:state"
       {:get [:get-registration-methods (bifrost/interceptor
                                         channels/registration-methods-read
                                         (config [:timeouts :registration-methods-read]))]}
       ^:interceptors [(bifrost.i/update-in-response [:body :registration-methods]
-                                                    [:body] identity)
-                      (bifrost.i/update-in-request [:query-params]
-                                                   language-coercer)]]
+                                                    [:body] identity)]]
      ["/registrations"
-      ^:interceptors [(bifrost.i/update-in-request [:query-params]
-                                                   language-coercer)]
       {:post [:post-registration (bifrost/interceptor
                                   channels/voter-register
                                   (config [:timeouts :voter-register]))]}]

--- a/test/voter_registration_http_api/service_test.clj
+++ b/test/voter_registration_http_api/service_test.clj
@@ -35,7 +35,7 @@
     (let [http-response-ch (async/thread
                              (http/get (str/join "/" [root-url
                                                       "registration-methods"
-                                                      "co"])
+                                                      "co?language=all"])
                                        {:headers {:accept "application/edn"}}))
           [response-ch message] (async/alt!! channels/registration-methods-read ([v] v)
                                              (async/timeout 1000) [nil ::timeout])
@@ -51,7 +51,8 @@
         (assert (not= http-response ::timeout))
         (is (= "co" (:state message)))
         (is (= 200 (:status http-response)))
-        (is (= (:registration-methods response) body-data)))))
+        (is (= (:registration-methods response) body-data))
+        (is (= :all (:language message))))))
   (testing "GET to /registration-methods/:state can respond with Transit"
     (let [http-response-ch (async/thread
                              (http/get (str/join "/" [root-url
@@ -125,7 +126,7 @@
                                                     :postal-code "73013"}}}}
           http-response-ch (async/thread
                              (http/post (str/join "/" [root-url
-                                                       "/registrations"])
+                                                       "/registrations?language=all"])
                                         {:headers {:accept "application/edn"
                                                    :content-type "application/edn"}
                                          :body (pr-str post-data)}))
@@ -141,7 +142,8 @@
         (assert (not= http-response ::timeout))
         (is (= :ok (:state message)))
         (is (= 200 (:status http-response)))
-        (is (= (dissoc response :status) body-data)))))
+        (is (= (dissoc response :status) body-data))
+        (is (= :all (:language message))))))
   (testing "GET to /registration-methods/:state can receive & respond with Transit"
     (let [post-data {:state :ny
                      :method :paper
@@ -181,7 +183,8 @@
         (assert (not= http-response ::timeout))
         (is (= :ny (:state message)))
         (is (= 200 (:status http-response)))
-        (is (= (dissoc response :status) body-data)))))
+        (is (= (dissoc response :status) body-data))
+        (is (not (contains? message :language))))))
   (testing "error from backend service results in HTTP server error response"
     (let [post-data {:state :co
                      :method :online

--- a/test/voter_registration_http_api/service_test.clj
+++ b/test/voter_registration_http_api/service_test.clj
@@ -144,7 +144,7 @@
         (is (= 200 (:status http-response)))
         (is (= (dissoc response :status) body-data))
         (is (= :all (:language message))))))
-  (testing "GET to /registration-methods/:state can receive & respond with Transit"
+  (testing "POST to /registrations can receive & respond with Transit"
     (let [post-data {:state :ny
                      :method :paper
                      :voter {:email "rockiesgm@example.com"


### PR DESCRIPTION
Requested work based on [this](https://github.com/democracyworks/voter-registration-works/pull/28) PR, passes along the language query param for the `/registrations` endpoint.